### PR TITLE
Use PORT0 as listen port if running in marathon

### DIFF
--- a/marathon.json
+++ b/marathon.json
@@ -30,7 +30,7 @@
       "network": "BRIDGE",
       "portMappings": [
         {
-          "containerPort": 5000,
+          "containerPort": 0,
           "hostPort": 0,
           "servicePort": 5000,
           "protocol": "tcp"

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -20,4 +20,7 @@ if (process.env.ZOOKEEPER_PATH) {
   config.zookeeperPath = process.env.ZOOKEEPER_PATH;
 }
 
+if (process.env.PORT0) {
+  config.port = process.env.PORT0;
+}
 module.exports = config;


### PR DESCRIPTION
Use PORT0 as listen port if running in marathon.

It's very useful if bridge network is disabled.