### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:4.4.7
+FROM mhart/alpine-node:6.5
 
 MAINTAINER Graham Taylor <gtayzlor@gmail.com>
 


### PR DESCRIPTION
failed to build docker image with mhart/alpine-node:4.4.7